### PR TITLE
refactor: 일기 API에서 userId 삭제 및 일기 작성/조회에서 imageUrl 추가

### DIFF
--- a/src/main/java/com/lifelog/diary/common/file/FileUtil.java
+++ b/src/main/java/com/lifelog/diary/common/file/FileUtil.java
@@ -6,4 +6,16 @@ public class FileUtil {
     public static boolean isImageFile(String mimeType) {
         return (mimeType != null) && (mimeType.equals("image/jpeg") || mimeType.equals("image/jpg") || mimeType.equals("image/png") );
     }
+
+    public static String getExtensionFromMimeType(String mimeType) {
+        if (mimeType == null) {
+            return "";
+        }
+
+        return switch (mimeType) {
+            case "image/jpeg", "image/jpg" -> ".jpg";
+            case "image/png" -> ".png";
+            default -> "";
+        };
+    }
 }

--- a/src/main/java/com/lifelog/diary/controller/ChatController.java
+++ b/src/main/java/com/lifelog/diary/controller/ChatController.java
@@ -1,6 +1,7 @@
 package com.lifelog.diary.controller;
 
 import com.lifelog.diary.dto.ChatMessageReqDto;
+import com.lifelog.diary.service.AccountService;
 import com.lifelog.diary.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -9,19 +10,25 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 @RestController
 @RequestMapping("/chat")
 @RequiredArgsConstructor
 public class ChatController {
     private final ChatService chatService;
+    private final AccountService accountService;
 
     @PostMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<String> streamDiaryFromConversation(@RequestBody ChatMessageReqDto reqDto) {
-        return chatService.chatAndCreateDiary(
-                reqDto.getUserId(),
-                reqDto.getConversation(),
-                reqDto.getCurrentDiary()
-        );
+    public Flux<String> streamDiaryFromConversation(
+            @RequestBody ChatMessageReqDto reqDto) {
+        return Mono.fromCallable(accountService::getCurrentUser)
+                .subscribeOn(Schedulers.boundedElastic())  // 블로킹 호출 별도 스레드에서 실행
+                .flatMapMany(user -> chatService.chatAndCreateDiary(
+                        reqDto.getConversation(),
+                        reqDto.getCurrentDiary(),
+                        user
+                ));
     }
 }

--- a/src/main/java/com/lifelog/diary/controller/DiaryController.java
+++ b/src/main/java/com/lifelog/diary/controller/DiaryController.java
@@ -6,6 +6,7 @@ import com.lifelog.diary.common.response.enums.Code;
 import com.lifelog.diary.dto.DiaryReqDto;
 import com.lifelog.diary.dto.DiaryUpdateDto;
 import com.lifelog.diary.dto.DiaryResDto;
+import com.lifelog.diary.service.AccountService;
 import com.lifelog.diary.service.DiaryService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,16 +19,18 @@ import java.util.Optional;
 public class DiaryController {
 
     private final DiaryService diaryService;
+    private final AccountService accountService;
 
-    public DiaryController(DiaryService diaryService) {
+    public DiaryController(DiaryService diaryService, AccountService accountService) {
         this.diaryService = diaryService;
+        this.accountService = accountService;
     }
 
     @PostMapping
     public ResponseEntity<ResponseDto<DiaryResDto>> createDiary(
             @RequestBody DiaryReqDto dto
     ) {
-        DiaryResDto diary = diaryService.createDiary(dto);
+        DiaryResDto diary = diaryService.createDiary(accountService.getCurrentUser(), dto);
 
         MetaResponseDto meta = new MetaResponseDto(Code.OK, "일기 생성 성공");
         List<DiaryResDto> data = List.of(diary);
@@ -50,9 +53,9 @@ public class DiaryController {
         }
     }
 
-    @GetMapping("/user/{userId}")
-    public ResponseEntity<ResponseDto<DiaryResDto>> getDiaries(@PathVariable Long userId) {
-        List<DiaryResDto> diaries = diaryService.getByUserId(userId);
+    @GetMapping("/user")
+    public ResponseEntity<ResponseDto<DiaryResDto>> getDiaries() {
+        List<DiaryResDto> diaries = diaryService.getByUserId(accountService.getCurrentUserId());
         MetaResponseDto meta = new MetaResponseDto(Code.OK, "사용자의 일기 목록 조회 성공");
         return ResponseEntity.ok(new ResponseDto<>(meta, diaries));
     }

--- a/src/main/java/com/lifelog/diary/controller/DiaryController.java
+++ b/src/main/java/com/lifelog/diary/controller/DiaryController.java
@@ -30,7 +30,9 @@ public class DiaryController {
     public ResponseEntity<ResponseDto<DiaryResDto>> createDiary(
             @RequestBody DiaryReqDto dto
     ) {
-        DiaryResDto diary = diaryService.createDiary(accountService.getCurrentUser(), dto);
+        DiaryResDto diary = diaryService.createDiary(
+                accountService.getCurrentUser(), dto.getContent(), dto.getImageUrl()
+        );
 
         MetaResponseDto meta = new MetaResponseDto(Code.OK, "일기 생성 성공");
         List<DiaryResDto> data = List.of(diary);

--- a/src/main/java/com/lifelog/diary/domain/Diary.java
+++ b/src/main/java/com/lifelog/diary/domain/Diary.java
@@ -21,10 +21,14 @@ public class Diary extends BaseTimeEntity {
     @Column(name = "content", nullable = false)
     private String content;
 
+    @Column(name = "imageUrl")
+    private String imageUrl;
+
     @Builder
-    private Diary(User user, String content) {
+    private Diary(User user, String content, String imageUrl) {
         this.user = user;
         this.content = content;
+        this.imageUrl = imageUrl;
     }
 
 }

--- a/src/main/java/com/lifelog/diary/dto/ChatMessageReqDto.java
+++ b/src/main/java/com/lifelog/diary/dto/ChatMessageReqDto.java
@@ -7,7 +7,6 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChatMessageReqDto {
-    private Long userId;
     private String conversation;
     private String currentDiary;
 }

--- a/src/main/java/com/lifelog/diary/dto/DiaryReqDto.java
+++ b/src/main/java/com/lifelog/diary/dto/DiaryReqDto.java
@@ -10,6 +10,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class DiaryReqDto {
-    private Long userId;
     private String content;
 }

--- a/src/main/java/com/lifelog/diary/dto/DiaryReqDto.java
+++ b/src/main/java/com/lifelog/diary/dto/DiaryReqDto.java
@@ -11,4 +11,5 @@ import lombok.NoArgsConstructor;
 @Builder
 public class DiaryReqDto {
     private String content;
+    private String imageUrl;
 }

--- a/src/main/java/com/lifelog/diary/dto/DiaryResDto.java
+++ b/src/main/java/com/lifelog/diary/dto/DiaryResDto.java
@@ -12,5 +12,6 @@ import lombok.NoArgsConstructor;
 public class DiaryResDto {
     private Long diaryId;
     private String content;
+    private String imageUrl;
     private String createdAt;
 }

--- a/src/main/java/com/lifelog/diary/dto/DiaryResDto.java
+++ b/src/main/java/com/lifelog/diary/dto/DiaryResDto.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 @Builder
 public class DiaryResDto {
     private Long diaryId;
-    private Long userId;
     private String content;
     private String createdAt;
 }

--- a/src/main/java/com/lifelog/diary/image/service/ImageService.java
+++ b/src/main/java/com/lifelog/diary/image/service/ImageService.java
@@ -1,6 +1,7 @@
 package com.lifelog.diary.image.service;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.lifelog.diary.common.file.FileConstant;
 import com.lifelog.diary.common.file.FileUtil;
 import com.lifelog.diary.common.response.enums.Code;
@@ -16,10 +17,13 @@ import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignReques
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.UUID;
 
@@ -100,4 +104,44 @@ public class ImageService {
             throw new RuntimeException("Presigned URL 생성에 실패하였습니다.", e);
         }
     }
+
+    public String uploadImageFromUrl(String imageUrl) {
+        try {
+            // 외부 URL에서 이미지 다운로드
+            URL url = new URL(imageUrl);
+            URLConnection connection = url.openConnection();
+            String mimeType = connection.getContentType();
+            long contentLength = connection.getContentLengthLong();
+
+            if (contentLength > FileConstant.MAX_IMAGE_SIZE) {
+                throw new GeneralException(Code.FILE_SIZE_EXCEEDED);
+            }
+
+            if (!FileUtil.isImageFile(mimeType)) {
+                throw new GeneralException(Code.INVALID_FILE_TYPE);
+            }
+
+            String originalFileName = Paths.get(url.getPath()).getFileName().toString();
+            if (originalFileName.isBlank()) {
+                String fileExtension = FileUtil.getExtensionFromMimeType(mimeType);
+                originalFileName = "image" + fileExtension;
+            }
+            String fileName = "diary-images/" + UUID.randomUUID() + originalFileName;
+
+            // S3 업로드
+            try (InputStream inputStream = connection.getInputStream()) {
+                ObjectMetadata metadata = new ObjectMetadata();
+                metadata.setContentLength(contentLength);
+                metadata.setContentType(mimeType);
+
+                amazonS3.putObject(bucketName, fileName, inputStream, metadata);
+            }
+
+            return amazonS3.getUrl(bucketName, fileName).toString();
+
+        } catch (IOException e) {
+            throw new GeneralException(Code.FILE_UPLOAD_ERROR);
+        }
+    }
+
 }

--- a/src/main/java/com/lifelog/diary/service/ChatService.java
+++ b/src/main/java/com/lifelog/diary/service/ChatService.java
@@ -1,5 +1,6 @@
 package com.lifelog.diary.service;
 
+import com.lifelog.diary.domain.User;
 import com.lifelog.diary.dto.DiaryReqDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,7 +15,7 @@ public class ChatService {
     private final DiaryService diaryService;
     private final FollowQuestionService followQuestionService;
 
-    public Flux<String> chatAndCreateDiary(Long userId, String conversation, String currentDiary) {
+    public Flux<String> chatAndCreateDiary(String conversation, String currentDiary, User user) {
         boolean isDiaryPresent = currentDiary != null && !currentDiary.isBlank();
 
         if (isDiaryPresent) {
@@ -22,7 +23,7 @@ public class ChatService {
             return gptService.streamDiaryFromConversation(conversation)
                     .publishOn(Schedulers.boundedElastic())
                     .doOnNext(diaryBuilder::append)
-                    .doOnComplete(() -> diaryService.createDiary(new DiaryReqDto(userId, diaryBuilder.toString())));
+                    .doOnComplete(() -> diaryService.createDiary(user, new DiaryReqDto(diaryBuilder.toString())));
         }
 
         if (conversation == null || conversation.isBlank()) {

--- a/src/main/java/com/lifelog/diary/service/ChatService.java
+++ b/src/main/java/com/lifelog/diary/service/ChatService.java
@@ -23,7 +23,7 @@ public class ChatService {
             return gptService.streamDiaryFromConversation(conversation)
                     .publishOn(Schedulers.boundedElastic())
                     .doOnNext(diaryBuilder::append)
-                    .doOnComplete(() -> diaryService.createDiary(user, new DiaryReqDto(diaryBuilder.toString())));
+                    .map(token -> "DIARY: " + token);
         }
 
         if (conversation == null || conversation.isBlank()) {

--- a/src/main/java/com/lifelog/diary/service/DiaryService.java
+++ b/src/main/java/com/lifelog/diary/service/DiaryService.java
@@ -1,13 +1,10 @@
 package com.lifelog.diary.service;
 
-import com.lifelog.diary.common.response.enums.Code;
-import com.lifelog.diary.common.response.exception.GeneralException;
 import com.lifelog.diary.domain.Diary;
 import com.lifelog.diary.domain.User;
 import com.lifelog.diary.dto.DiaryReqDto;
 import com.lifelog.diary.dto.DiaryResDto;
 import com.lifelog.diary.repository.DiaryRepository;
-import com.lifelog.diary.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,7 +16,6 @@ import java.util.Optional;
 public class DiaryService {
 
     private final DiaryRepository diaryRepository;
-    private final UserRepository userRepository;
 
     public Optional<DiaryResDto> getById(Long diaryId) {
         return diaryRepository.findById(String.valueOf(diaryId))
@@ -49,10 +45,7 @@ public class DiaryService {
         return true;
     }
 
-    public DiaryResDto createDiary(DiaryReqDto dto) {
-        User user = userRepository.findById(dto.getUserId())
-                .orElseThrow(() -> new GeneralException(Code.USER_NOT_FOUND));
-
+    public DiaryResDto createDiary(User user, DiaryReqDto dto) {
         Diary diary = Diary.builder()
                 .user(user)
                 .content(dto.getContent())
@@ -66,7 +59,6 @@ public class DiaryService {
     private DiaryResDto convertToDto(Diary diary) {
         return DiaryResDto.builder()
                 .diaryId(diary.getId())
-                .userId(diary.getUser().getId())
                 .content(diary.getContent())
                 .createdAt(diary.getCreatedAt().toString())
                 .build();

--- a/src/main/java/com/lifelog/diary/service/DiaryService.java
+++ b/src/main/java/com/lifelog/diary/service/DiaryService.java
@@ -2,8 +2,8 @@ package com.lifelog.diary.service;
 
 import com.lifelog.diary.domain.Diary;
 import com.lifelog.diary.domain.User;
-import com.lifelog.diary.dto.DiaryReqDto;
 import com.lifelog.diary.dto.DiaryResDto;
+import com.lifelog.diary.image.service.ImageService;
 import com.lifelog.diary.repository.DiaryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +16,7 @@ import java.util.Optional;
 public class DiaryService {
 
     private final DiaryRepository diaryRepository;
+    private final ImageService imageService;
 
     public Optional<DiaryResDto> getById(Long diaryId) {
         return diaryRepository.findById(String.valueOf(diaryId))
@@ -46,10 +47,12 @@ public class DiaryService {
     }
 
     public DiaryResDto createDiary(User user, String diaryContent, String imageUrl) {
+        String diaryImageUrl = imageService.uploadImageFromUrl(imageUrl);
+
         Diary diary = Diary.builder()
                 .user(user)
                 .content(diaryContent)
-                .imageUrl(imageUrl)
+                .imageUrl(diaryImageUrl)
                 .build();
 
         Diary savedDiary = diaryRepository.save(diary);
@@ -58,9 +61,12 @@ public class DiaryService {
     }
 
     private DiaryResDto convertToDto(Diary diary) {
+        String presignedImageUrl = imageService.generatePresignedUrlFromFullUrl(diary.getImageUrl());
+
         return DiaryResDto.builder()
                 .diaryId(diary.getId())
                 .content(diary.getContent())
+                .imageUrl(presignedImageUrl)
                 .createdAt(diary.getCreatedAt().toString())
                 .build();
     }

--- a/src/main/java/com/lifelog/diary/service/DiaryService.java
+++ b/src/main/java/com/lifelog/diary/service/DiaryService.java
@@ -45,10 +45,11 @@ public class DiaryService {
         return true;
     }
 
-    public DiaryResDto createDiary(User user, DiaryReqDto dto) {
+    public DiaryResDto createDiary(User user, String diaryContent, String imageUrl) {
         Diary diary = Diary.builder()
                 .user(user)
-                .content(dto.getContent())
+                .content(diaryContent)
+                .imageUrl(imageUrl)
                 .build();
 
         Diary savedDiary = diaryRepository.save(diary);


### PR DESCRIPTION
[피드백 반영 현황]

- ImageService에 uploadImageFromUrl 메서드를 만들어, url을 기반으로 이미지를 S3에 업로드하도록 구현했습니다.
- 기존 DiarService의 convertToDto 메서드에 presignedImageUrl을 받아 DiaryResDto에 반영하는 로직을 추가했습니다.